### PR TITLE
Fixes port selection resetting after updating the list

### DIFF
--- a/python-lib/line_flash/ui.py
+++ b/python-lib/line_flash/ui.py
@@ -250,8 +250,13 @@ def main():
             event.accept()
 
     def set_ports(port_list):
+        current_selection = transport_port_combobox.currentText()
         transport_port_combobox.clear()
         transport_port_combobox.addItems(port_list)
+        if current_selection in port_list:
+            transport_port_combobox.setCurrentText(current_selection)
+        else:
+            transport_port_combobox.setCurrentIndex(0)
 
     def start_flash():
         clear_logs()


### PR DESCRIPTION
## Brief

- When the port list is updated every 5 second the option selected by the user was also reset
- With this change the selection is restored, but if the option is no longer available then the first port in the list
  will be selected